### PR TITLE
use watcher package to watch content changes

### DIFF
--- a/lib/dsg.dart
+++ b/lib/dsg.dart
@@ -8,6 +8,7 @@ import 'dart:math';
 import 'package:intl/intl.dart';
 import 'package:args/args.dart';
 import 'package:markdown/markdown.dart';
+import 'package:watcher/watcher.dart';
 import 'package:where/where.dart';
 
 import 'package:logging/logging.dart';

--- a/lib/src/application.dart
+++ b/lib/src/application.dart
@@ -199,14 +199,14 @@ class Application {
 
     final Directory srcDir = new Directory(folder);
 
-    srcDir
-        .watch(recursive: true)
-        .where((final file) => (!file.path.contains("packages")))
-        .listen((final FileSystemEvent event) {
+    var watcher = DirectoryWatcher(srcDir.path);
+    watcher.events
+        .where((final event) => (!event.path.contains("packages")))
+        .listen((final event) {
       _logger.info(event.toString());
       if (timerWatch == null) {
-        timerWatch = new Timer(new Duration(milliseconds: 1000), () {
-          new Generator().generate(config);
+        timerWatch = Timer(Duration(milliseconds: 1000), () {
+          Generator().generate(config);
           timerWatch = null;
         });
       }
@@ -293,6 +293,38 @@ class Application {
       _logger.info("Found no SCSS without a _ at the beginning...");
     }
   }
+
+  // void _watchDir({
+  //   Directory dir,
+  //   int events,
+  //   Function(FileSystemEvent event) whereFilter,
+  //   Function(FileSystemEvent event) listener,
+  //   bool recursive,
+  // }) async {
+  //   if (Platform.isLinux) {
+  //     final dirList = dir
+  //         .listSync(recursive: true)
+  //         .where((entity) => FileSystemEntity.isDirectorySync(entity.path));
+
+  //     for (final dir in dirList) {
+  //       print("WATCH: ${dir.path}");
+  //       dir.watch(events: events, recursive: false).listen(
+  //           (e) => print("file change: $e"),
+  //           onError: (e, stack) => print("$e $stack"));
+  //     }
+  //     // dirList.forEach((dir) {
+  //     //   print("WATCH: ${dir.path}");
+  //     //   dir.watch(events: events, recursive: false).listen(
+  //     //       (e) => print("file change: $e"),
+  //     //       onError: (e, stack) => print("$e $stack"));
+  //     // });
+  //   } else {
+  //     dir
+  //         .watch(events: events, recursive: recursive)
+  //         .where(whereFilter)
+  //         .listen(listener);
+  //   }
+  // }
 
   void _testPreconditions(final CommandManager cm, final Config config) {
     // if not using sass or prefixer, dont check for them being available

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -569,7 +569,7 @@ packages:
     source: hosted
     version: "4.1.0"
   watcher:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: watcher
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,8 @@ dependencies:
   where: ^6.0.0
   
   packages: ^0.4.0
+
+  watcher:
     
 dev_dependencies:
   test: any


### PR DESCRIPTION
use the [watcher package](https://pub.dev/packages/watcher) as it polyfills on Linux for lack of recursive watching in inotify and hence in the dart:io watch() method on Linux

fixes: #8 